### PR TITLE
geventhttpclient 2.3.4 

### DIFF
--- a/recipe/0001-link-system-llhttp.patch
+++ b/recipe/0001-link-system-llhttp.patch
@@ -1,0 +1,56 @@
+diff --git a/setup.py b/setup.py
+index bd8caee..64d3782 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1,21 +1,36 @@
+ from distutils.core import setup
+-
+ from setuptools.extension import Extension
++import os
++import sysconfig
++
++# link against system libllhttp from the conda env (package: libllhttp)
++prefix = (
++    os.environ.get("PREFIX")
++    or os.environ.get("CONDA_PREFIX")
++    or sysconfig.get_config_var("prefix")
++    or ""
++)
++
++include_dirs = ["ext"]
++library_dirs = []
++libraries = ["llhttp"]  # -lllhttp everywhere
++
++if prefix:
++    if os.name == "nt":
++        # Windows: <env>\Library\include, <env>\Library\lib
++        include_dirs.append(os.path.join(prefix, "Library", "include", "llhttp"))
++        library_dirs.append(os.path.join(prefix, "Library", "lib"))
++    else:
++        # POSIX: <env>/include, <env>/lib
++        include_dirs.append(os.path.join(prefix, "include", "llhttp"))
++        library_dirs.append(os.path.join(prefix, "lib"))
+ 
+ http_parser = Extension(
+     "geventhttpclient._parser",
+-    sources=[
+-        "ext/_parser.c",
+-        "llhttp/src/api.c",
+-        "llhttp/src/http.c",
+-        "llhttp/src/llhttp.c",
+-    ],
+-    include_dirs=[
+-        "ext",
+-        "llhttp/include",
+-    ],
++    sources=["ext/_parser.c"],  # use only project C; llhttp is external now
++    include_dirs=include_dirs,
++    library_dirs=library_dirs,
++    libraries=libraries,
+ )
+ 
+-setup(
+-    ext_modules=[http_parser],
+-)
++setup(ext_modules=[http_parser])
+\ No newline at end of file

--- a/recipe/0002-llhttp-new-ver-signature-fix.patch
+++ b/recipe/0002-llhttp-new-ver-signature-fix.patch
@@ -1,0 +1,41 @@
+diff --git a/ext/_parser.c b/ext/_parser.c
+index b3d687c..3c101b8 100644
+--- a/ext/_parser.c
++++ b/ext/_parser.c
+@@ -2,6 +2,7 @@
+ #include <Python.h>
+ #include "Python_compat.h"
+ #include <llhttp.h>
++#include <stddef.h>  /* for size_t */
+ #include <stdio.h>
+ 
+ static PyObject * PyExc_HTTPParseError;
+@@ -141,15 +142,26 @@ static int on_body(llhttp_t* parser, const char *at, size_t length)
+     return fail;
+ }
+ 
++
++static int on_headers_complete_data(llhttp_t* p, const char* at, size_t length) {
++    (void)at; (void)length;
++    return on_headers_complete(p);
++}
++
++static int on_message_complete_data(llhttp_t* p, const char* at, size_t length) {
++    (void)at; (void)length;
++    return on_message_complete(p);
++}
++
+ static llhttp_settings_t _parser_settings = {
+     on_message_begin,
+     NULL, // on_url
+     on_status,
+     on_header_field,
+     on_header_value,
+-    on_headers_complete,
++    on_headers_complete_data,
+     on_body,
+-    on_message_complete
++    on_message_complete_data
+ };
+ 
+ static PyObject*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,6 @@ build:
   number: 0
   skip: true  # [py<39 or py>=313]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
-  # ignore_run_exports:
-  #   - libcxx  # [osx]
 
 requirements:
   build:
@@ -28,20 +26,35 @@ requirements:
     - wheel
   run:
     - python
-    - gevent
+    - gevent >=23.9.1
     - certifi
-    - brotli
+    - brotli-python
     - urllib3
 
-# test:
-#   requires:
-#     - pip
-#     - pytest
-#     - brotli
-#   imports:
-#     - geventhttpclient
-#   commands:
-#     - pip check
+# sdist have not all tests files to complete testing,
+# so that test files used tests.common imports have been removed
+{% set SKIP_TEST_FILES = [
+    "tests/test_client.py",
+    "tests/test_httplib.py",
+    "tests/test_network_failures.py",
+    "tests/test_requests.py",
+    "tests/test_ssl.py",
+    "tests/test_useragent.py"
+] %}
+
+test:
+  source_files:
+    - tests
+  requires:
+    - pip
+    - pytest
+    - brotli-python
+  imports:
+    - geventhttpclient
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest tests {% for file in SKIP_TEST_FILES %} --ignore={{ file }}{% endfor %} -v
 
 about:
   home: https://github.com/geventhttpclient/geventhttpclient

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "geventhttpclient" %}
-{% set version = "1.4.5" %}
+{% set version = "2.3.4" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,6 +53,40 @@ requirements:
     "tests/test_useragent.py",
 ] %}
 
+# FAILED tests/test_headers.py::test_read_multiple_header - KeyError: 'set-cookie'
+# FAILED tests/test_headers.py::test_cookielib_compatibility - assert 0 == 3
+#  +  where 0 = len([])
+# FAILED tests/test_headers.py::test_compatibility_with_previous_api_read - KeyError: 'content-encoding'
+# FAILED tests/test_keep_alive.py::test_keep_alive_http_10_without_header - assert False
+#  +  where False = <HTTPResponse status=200 headers={}>.message_complete
+# FAILED tests/test_keep_alive.py::test_keep_alive_bodyless_response_with_body - _parser.HTTPParseError: (None, 1)
+# FAILED tests/test_keep_alive.py::test_keep_alive_bodyless_10x_request_with_body - assert False
+#  +  where False = should_close()
+#  +    where should_close = <HTTPResponse status=100 headers={}>.should_close
+# FAILED tests/test_keep_alive.py::test_close_connection_and_no_content_length - AssertionError: assert bytearray(b'Connection') == bytearray(b'Hello World!')
+#   At index 0 diff: 67 != 72
+#   Right contains 2 more items, first extra item: 100
+
+#   Full diff:
+#   - bytearray(b'Hello World!')
+#   + bytearray(b'Connection')
+# FAILED tests/test_keep_alive.py::test_close_connection_with_content_length - AssertionError: assert bytearray(b'Content-lengthConnection') == bytearray(b'12345')
+
+#   At index 0 diff: 67 != 49
+#   Left contains 19 more items, first extra item: 110
+
+#   Full diff:
+#   - bytearray(b'12345')
+#   + bytearray(b'Content-lengthConnection')
+# FAILED tests/test_parser.py::test_parse_small_blocks - AssertionError: assert [] == [('Cache-Control', 'public, max-age=2592000'), ('Content-Length', '218'), ('Content-Type', 'text/html; charset=UTF-8'), ('Date', 'Thu, 13 Oct 2011 15:03:12 GMT'), ('Expires', 'Sat, 12 Nov 2011 15:03:12 GMT'), ('Location', 'http://www.google.fr/'), ('Server', 'gws'), ('X-XSS-Protection', '1; mode=block')]
+
+#   Right contains 8 more items, first extra item: ('Cache-Control', 'public, max-age=2592000')
+
+# FAILED tests/test_parser.py::test_parse_error - assert 'Invalid response status' in "('Invalid status code', 13)"
+#  +  where "('Invalid status code', 13)" = str(HTTPParseError('Invalid status code', 13))
+# FAILED tests/test_parser.py::test_incomplete_response - assert False
+#  +  where False = should_close()
+#  +    where should_close = <HTTPResponse status=200 headers={}>.should_close
 {% set SKIP_TEST_LIST = [
     "test_parse_error",
     "test_incomplete_response",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<39]
+  skip: true  # [py<39 or py>=313]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   # ignore_run_exports:
   #   - libcxx  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
   build:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
   host:
     - python
     - pip
@@ -51,6 +50,16 @@ test:
     - brotli-python
   imports:
     - geventhttpclient
+    - geventhttpclient._parser
+    - geventhttpclient.api
+    - geventhttpclient.client
+    - geventhttpclient.connectionpool
+    - geventhttpclient.header
+    - geventhttpclient.httplib
+    - geventhttpclient.requests
+    - geventhttpclient.response
+    - geventhttpclient.url
+    - geventhttpclient.useragent
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,10 +9,17 @@ source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 1749f75810435a001fc6d4d7526c92cf02b39b30ab6217a886102f941c874222
 
+  patches:
+    - 0001-link-system-llhttp.patch
+    - 0002-llhttp-new-ver-signature-fix.patch
+
 build:
   number: 0
-  skip: true  # [py<39 or py>=313]
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+  skip: true  # [py<39]
+  script: |
+    # Unverndoring llhttp from sdist
+    rm -rf llhttp || true
+    {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   build:
@@ -23,8 +30,10 @@ requirements:
     - pip
     - setuptools
     - wheel
+    - libllhttp
   run:
     - python
+    - libllhttp
     - gevent
     - certifi
     - brotli-python
@@ -32,14 +41,45 @@ requirements:
 
 # sdist have not all tests files to complete testing,
 # so that test files used tests.common imports have been removed
+# No module named 'test'
+# No module named 'httplib2'
 {% set SKIP_TEST_FILES = [
     "tests/test_client.py",
     "tests/test_httplib.py",
+    "tests/test_httplib2.py",
     "tests/test_network_failures.py",
     "tests/test_requests.py",
     "tests/test_ssl.py",
-    "tests/test_useragent.py"
+    "tests/test_useragent.py",
 ] %}
+
+{% set SKIP_TEST_OSX = [
+    "test_read_multiple_header",
+    "test_cookielib_compatibility",
+    "test_compatibility_with_previous_api_read",
+    "test_keep_alive_http_10_without_header",
+    "test_keep_alive_bodyless_response_with_body",
+    "test_keep_alive_bodyless_10x_request_with_body",
+    "test_close_connection_and_no_content_length",
+    "test_parse_error",
+    "test_incomplete_response",
+    "test_parse_small_blocks",
+    "test_close_connection_with_content_length",
+] %}
+
+{% set SKIP_TEST_LINUX = [
+] %}
+
+{% set SKIP_TEST_WIN = [
+] %}
+
+{% set SKIP_TEST_LIST = [
+] %}
+
+{% set SKIP_TEST_LIST = SKIP_TEST_LIST + SKIP_TEST_OSX %}  # [osx]
+{% set SKIP_TEST_LIST = SKIP_TEST_LIST + SKIP_TEST_LINUX %}  # [linux]
+{% set SKIP_TEST_LIST = SKIP_TEST_LIST + SKIP_TEST_WIN %}  # [win]
+
 
 test:
   source_files:
@@ -63,15 +103,13 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest tests {% for file in SKIP_TEST_FILES %} --ignore={{ file }}{% endfor %} -v
+    - pytest -ra -vv tests {% for file in SKIP_TEST_FILES %} --ignore={{ file }}{% endfor %} -k "not ({{ SKIP_TEST_LIST | join(' or ') }})"
 
 about:
   home: https://github.com/geventhttpclient/geventhttpclient
   license: MIT
   license_family: MIT
-  license_file:
-    - LICENSE-MIT
-    - llhttp/LICENSE-MIT
+  license_file: LICENSE-MIT
   summary: A high performance, concurrent http client library for python with gevent
 
   # The remaining entries in this section are optional, but recommended.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,9 +68,11 @@ requirements:
 ] %}
 
 {% set SKIP_TEST_LINUX = [
+  "stub"
 ] %}
 
 {% set SKIP_TEST_WIN = [
+  "stub"
 ] %}
 
 {% set SKIP_TEST_LIST = [

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,17 +6,19 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 3f0ab18d84ef26ba0c9df73ae2a41ba30a46072b447f2e36c740400de4a63d44
-  - url: https://raw.githubusercontent.com/{{ name }}/{{ name }}/master/LICENSE.txt
-    sha256: ae64cc65b9d6623cf0e9e6e90f56cac626cd1fd088d48d0585902c266ec898e3
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/geventhttpclient-{{ version }}.tar.gz
+  sha256: 1749f75810435a001fc6d4d7526c92cf02b39b30ab6217a886102f941c874222
 
 build:
-  number: 1
-  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  number: 0
+  skip: true  # [py<39]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+  # ignore_run_exports:
+  #   - libcxx  # [osx]
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
@@ -26,23 +28,28 @@ requirements:
     - wheel
   run:
     - python
-    - gevent >=0.13
+    - gevent
     - certifi
-    - six
+    - brotli
+    - urllib3
 
-test:
-  requires:
-    - pip
-  imports:
-    - geventhttpclient
-  commands:
-    - python -m pip check
+# test:
+#   requires:
+#     - pip
+#     - pytest
+#     - brotli
+#   imports:
+#     - geventhttpclient
+#   commands:
+#     - pip check
 
 about:
   home: https://github.com/geventhttpclient/geventhttpclient
   license: MIT
   license_family: MIT
-  license_file: LICENSE.txt
+  license_file:
+    - LICENSE-MIT
+    - llhttp/LICENSE-MIT
   summary: A high performance, concurrent http client library for python with gevent
 
   # The remaining entries in this section are optional, but recommended.
@@ -65,7 +72,7 @@ about:
 
     Use of SSL/TLS with python 2.7.9 is not recommended and may be broken.
   dev_url: https://github.com/geventhttpclient/geventhttpclient
-  doc_url: https://github.com/geventhttpclient/geventhttpclient/blob/master/README.mdown
+  doc_url: https://github.com/geventhttpclient/geventhttpclient/blob/master/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,35 +53,19 @@ requirements:
     "tests/test_useragent.py",
 ] %}
 
-{% set SKIP_TEST_OSX = [
-    "test_read_multiple_header",
-    "test_cookielib_compatibility",
-    "test_compatibility_with_previous_api_read",
-    "test_keep_alive_http_10_without_header",
-    "test_keep_alive_bodyless_response_with_body",
-    "test_keep_alive_bodyless_10x_request_with_body",
-    "test_close_connection_and_no_content_length",
+{% set SKIP_TEST_LIST = [
     "test_parse_error",
     "test_incomplete_response",
     "test_parse_small_blocks",
     "test_close_connection_with_content_length",
+    "test_keep_alive_http_10_without_header",
+    "test_keep_alive_bodyless_response_with_body",
+    "test_keep_alive_bodyless_10x_request_with_body",
+    "test_close_connection_and_no_content_length",
+    "test_read_multiple_header",
+    "test_cookielib_compatibility",
+    "test_compatibility_with_previous_api_read",
 ] %}
-
-{% set SKIP_TEST_LINUX = [
-  "stub"
-] %}
-
-{% set SKIP_TEST_WIN = [
-  "stub"
-] %}
-
-{% set SKIP_TEST_LIST = [
-] %}
-
-{% set SKIP_TEST_LIST = SKIP_TEST_LIST + SKIP_TEST_OSX %}  # [osx]
-{% set SKIP_TEST_LIST = SKIP_TEST_LIST + SKIP_TEST_LINUX %}  # [linux]
-{% set SKIP_TEST_LIST = SKIP_TEST_LIST + SKIP_TEST_WIN %}  # [win]
-
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/geventhttpclient-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 1749f75810435a001fc6d4d7526c92cf02b39b30ab6217a886102f941c874222
 
 build:
@@ -25,7 +25,7 @@ requirements:
     - wheel
   run:
     - python
-    - gevent >=23.9.1
+    - gevent
     - certifi
     - brotli-python
     - urllib3


### PR DESCRIPTION
geventhttpclient 2.3.4 

**Destination channel:** Defaults

### Links

- [PKG-9159]
- dev_url:        https://github.com/geventhttpclient/geventhttpclient/tree/2.3.4
- conda_forge:    https://github.com/conda-forge/geventhttpclient-feedstock
- pypi:           https://pypi.org/project/geventhttpclient/2.3.4
- pypi inspector: https://inspector.pypi.io/project/geventhttpclient/2.3.4

### Explanation of changes:

- new version number


[PKG-9159]: https://anaconda.atlassian.net/browse/PKG-9159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ