### PR TITLE
geventhttpclient 2.3.9 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "geventhttpclient" %}
-{% set version = "2.3.4" %}
+{% set version = "2.3.9" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1749f75810435a001fc6d4d7526c92cf02b39b30ab6217a886102f941c874222
+  sha256: 16807578dc4a175e8d97e6e39d65a10b04b5237a8c55f7a5ef39044e869baeb8
 
   patches:
     - 0001-link-system-llhttp.patch
@@ -26,8 +26,8 @@ requirements:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
   host:
-    - python
     - pip
+    - python
     - setuptools
     - wheel
     - libllhttp


### PR DESCRIPTION
geventhttpclient 2.3.9 

**Destination channel:** Defaults

### Links

- [PKG-13390]
- dev_url:        https://github.com/geventhttpclient/geventhttpclient/tree/2.3.9
- conda_forge:    https://github.com/conda-forge/geventhttpclient-feedstock
- pypi:           https://pypi.org/project/geventhttpclient/2.3.9
- pypi inspector: https://inspector.pypi.io/project/geventhttpclient/2.3.9

### Explanation of changes:

- new version number


[PKG-13390]: https://anaconda.atlassian.net/browse/PKG-13390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ